### PR TITLE
Add line function to cycle-canvas

### DIFF
--- a/src/canvas-driver.js
+++ b/src/canvas-driver.js
@@ -43,8 +43,8 @@ function drawLine(context, element, origin) {
     context.setLineDash(element.style.lineDash);
   }
 
-  context.beginPath();
   context.moveTo(origin.x, origin.y);
+  context.beginPath();
   element.points.forEach(point => {
     context.lineTo(origin.x + point.x, origin.y + point.y);
   });
@@ -144,7 +144,15 @@ export function text (opts, children) {
 }
 
 export function line (opts, children) {
-  return c('line', opts, children);
+  const defaults = {
+    style: {
+      lineWidth: 1,
+      lineCap: 'butt',
+      lineJoin: 'miter',
+      strokeStyle: 'black'
+    }
+  };
+  return c('line', {...defaults, ...opts}, children);
 }
 
 export function makeCanvasDriver (selector, {width, height}) {


### PR DESCRIPTION
I implemented the line function with the following api:
line({
    points: [
      {x:0, y: 0},
      {x: 20, y: 20},
      {x: 40, y: 20},
      {x: 50, y: 30}
    ],
    style: {
      lineWidth: 2,
      strokeStyle: 'red',
      lineCap: 'butt',
      lineJoin: 'round',
      lineDash: [5, 2]
    }
})

I changed property `draw: []` (from rect and text) to `style: {}` for easier assignment of variable to context.
Please let me know if you have any thoughts or comments.
Thanks
