### PR TITLE
Convert vtree to instructions array and render separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "start": "babel-node ./examples/flappy-bird/server.js",
-    "test": "mocha --compilers js:babel-register",
+    "test": "mocha --compilers js:babel-core/register",
+    "autotest": "mocha --compilers js:babel-core/register --watch -R min",
     "bundle": "browserify ./examples/flappy-bird/index.js -t babelify -t uglifyify -o bundle.js",
     "precompile-lib": "rm -rf lib/ && mkdir -p lib",
     "compile-lib": "babel src -d lib",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepublish": "npm run compile-lib"
   },
   "files": [
-    "lib/"  
+    "lib/"
   ],
   "repository": {
     "type": "git",
@@ -38,20 +38,22 @@
     "@cycle/core": "^6.0.0-rc2",
     "@cycle/dom": "^9.0.1",
     "@cycle/isolate": "^1.2.0",
-    "babel-plugin-transform-object-rest-spread": "^6.6.5",
-    "babel-preset-es2015": "^6.1.18",
-    "box-collide": "^1.0.2",
-    "cycle-animation-driver": "^0.1.3",
-    "cycle-restart": "0.0.14",
-    "keycode": "^2.1.1",
-    "rx": "^4.0.7",
+    "assert": "^1.3.0",
     "babel-cli": "^6.2.0",
     "babel-core": "^6.2.1",
+    "babel-plugin-transform-object-rest-spread": "^6.6.5",
+    "babel-preset-es2015": "^6.1.18",
     "babelify": "^7.2.0",
+    "box-collide": "^1.0.2",
     "browserify": "^12.0.1",
     "browserify-hmr": "^0.3.1",
     "budo": "^6.1.0",
+    "cycle-animation-driver": "^0.1.3",
+    "cycle-restart": "0.0.14",
+    "keycode": "^2.1.1",
     "lodash": "^4.8.1",
+    "mocha": "^2.4.5",
+    "rx": "^4.0.7",
     "uglifyify": "^3.0.1"
   }
 }

--- a/src/canvas-driver.js
+++ b/src/canvas-driver.js
@@ -79,7 +79,7 @@ function translateLine (element, origin) {
       call: 'setLineDash',
       args: element.style.lineDash
     });
-  } 
+  }
 
   operations.push({
     call: 'moveTo',
@@ -102,7 +102,7 @@ function translateLine (element, origin) {
         origin.y + point.y
       ]
     });
-  })
+  });
 
   operations.push({
     call: 'stroke',
@@ -118,7 +118,7 @@ function translateLine (element, origin) {
 }
 
 function translateText (element, origin) {
-   return element.draw.map(operation => {
+  return element.draw.map(operation => {
     const operations = [
       {set: 'textAlign', value: element.textAlign || 'left'},
       {set: 'font', value: element.font}
@@ -132,7 +132,7 @@ function translateText (element, origin) {
 
     if (element.width) {
       args.push(element.width);
-    } 
+    }
 
     if (operation.fill) {
       operations.push({
@@ -215,32 +215,32 @@ export function renderInstructionsToCanvas (instructions, context) {
 
 function preDrawHooks (element) {
   const operations = [
-    {call: 'save', args: []}  
+    {call: 'save', args: []}
   ];
 
   if (element.transformations) {
-     element.transformations.forEach(transformation => {
-      if (transformation.translate) {
+    element.transformations.forEach(transformation => {
+       if (transformation.translate) {
         operations.push({
           call: 'translate',
           args: [transformation.translate.x, transformation.translate.y]
         });
       }
 
-      if (transformation.rotate) {
+       if (transformation.rotate) {
         operations.push({
           call: 'rotate',
           args: [transformation.rotate]
         });
       }
 
-      if (transformation.scale) {
+       if (transformation.scale) {
         operations.push({
           call: 'scale',
           args: [transformation.scale.x, transformation.scale.y]
         });
       }
-    });    
+     });
   }
 
   return operations;
@@ -248,7 +248,7 @@ function preDrawHooks (element) {
 
 function postDrawHooks () {
   return [
-    {call: 'restore', args: []}  
+    {call: 'restore', args: []}
   ];
 }
 

--- a/src/canvas-driver.js
+++ b/src/canvas-driver.js
@@ -1,3 +1,88 @@
+function flatten (array) {
+  if (typeof array.reduce !== 'function') {
+    return array;
+  }
+
+  return array.reduce((flatArray, arrayElement) => flatArray.concat(flatten(arrayElement)), []);
+}
+
+function compact (array) {
+  return array.filter(element => element !== undefined && element !== null);
+}
+
+function translateRect (element, origin) {
+  return element.draw.map(operation => {
+    const operations = [
+      {set: 'lineWidth', value: operation.lineWidth || 1}
+    ];
+
+    if (operation.clear) {
+      operations.push({
+        call: 'clearRect',
+        args: [
+          origin.x,
+          origin.y,
+          element.width,
+          element.height
+        ]
+      });
+    }
+
+    if (operation.fill) {
+      operations.push({
+        set: 'fillStyle',
+        value: operation.fill || 'black'
+      });
+
+      operations.push({
+        call: 'fillRect',
+        args: [
+          origin.x,
+          origin.y,
+          element.width,
+          element.height
+        ]
+      });
+    }
+
+    // TODO - test and implement stroke
+    if (operation.stroke) {
+      context.strokeStyle = operation.stroke || 'black';
+
+      context.strokeRect(
+        origin.x,
+        origin.y,
+        element.width,
+        element.height
+      );
+    }
+
+    return operations;
+  });
+}
+
+export function translateVtreeToInstructions (element) {
+  const elementMapping = {
+    rect: translateRect
+  };
+
+  const instructions = [
+    elementMapping[element.kind](element, {x: 0, y: 0})
+  ];
+
+  return compact(flatten(instructions));
+}
+
+export function renderInstructionsToCanvas (instructions, context) {
+  instructions.forEach(instruction => {
+    if (instruction.set) {
+      context[instruction.set] = instruction.value;
+    } else if (instruction.call) {
+      context[instruction.call](...instruction.args);
+    }
+  });
+}
+
 function renderElement (context, element, parent) {
   if (!element) {
     return;
@@ -60,10 +145,10 @@ function drawRect (context, element, origin) {
 
     if (operation.clear) {
       context.clearRect(
-          origin.x,
-          origin.y,
-          element.width,
-          element.height
+        origin.x,
+        origin.y,
+        element.width,
+        element.height
       );
     }
 
@@ -71,10 +156,10 @@ function drawRect (context, element, origin) {
       context.fillStyle = operation.fill || 'black';
 
       context.fillRect(
-          origin.x,
-          origin.y,
-          element.width,
-          element.height
+        origin.x,
+        origin.y,
+        element.width,
+        element.height
       );
     }
 
@@ -82,10 +167,10 @@ function drawRect (context, element, origin) {
       context.strokeStyle = operation.stroke || 'black';
 
       context.strokeRect(
-          origin.x,
-          origin.y,
-          element.width,
-          element.height
+        origin.x,
+        origin.y,
+        element.width,
+        element.height
       );
     }
   });

--- a/test/driver-test.js
+++ b/test/driver-test.js
@@ -9,7 +9,7 @@ function methodSpy () {
   const stub = (...args) => {
     called += 1;
     callArgs.push(args);
-  }
+  };
 
   stub.callCount = () => called;
   stub.callArgs = () => callArgs;
@@ -134,7 +134,7 @@ describe('canvasDriver', () => {
             y: 50,
             value: 'Hello World',
             font: '18pt Arial',
-            draw: [{fill: 'white'}]            
+            draw: [{fill: 'white'}]
           })
         ]
       });
@@ -166,7 +166,7 @@ describe('canvasDriver', () => {
         style: {
           lineCap: 'square',
           strokeStyle: '#CCCCCC',
-          lineDash: [5,15]
+          lineDash: [5, 15]
         },
         points: [
           {x: 10, y: 10},
@@ -176,7 +176,7 @@ describe('canvasDriver', () => {
         ]
       });
 
-      const instructions = translateVtreeToInstructions(vtree);      
+      const instructions = translateVtreeToInstructions(vtree);
 
       assert.deepEqual(
         instructions,
@@ -186,13 +186,13 @@ describe('canvasDriver', () => {
           {set: 'lineCap', value: 'square'},
           {set: 'lineJoin', value: 'mitter'},
           {set: 'strokeStyle', value: '#CCCCCC'},
-          {call: 'setLineDash', args: [5,15]},
+          {call: 'setLineDash', args: [5, 15]},
           {call: 'moveTo', args: [x, y]},
           {call: 'beginPath', args: []},
-          {call: 'lineTo', args: [x+10, y+10]},
-          {call: 'lineTo', args: [x+10, y+20]},
-          {call: 'lineTo', args: [x+20, y+10]},
-          {call: 'lineTo', args: [x+10, y+10]},
+          {call: 'lineTo', args: [x + 10, y + 10]},
+          {call: 'lineTo', args: [x + 10, y + 20]},
+          {call: 'lineTo', args: [x + 20, y + 10]},
+          {call: 'lineTo', args: [x + 10, y + 10]},
           {call: 'stroke', args: []},
           {call: 'setLineDash', args: []},
           {call: 'restore', args: []}
@@ -350,7 +350,7 @@ describe('canvasDriver', () => {
     it('takes a vtree and checks if the instructions array contain rotate transformation', () => {
       const vtree = rect({
         transformations: [
-          {rotate: (20*Math.PI/180)}
+          {rotate: (20 * Math.PI / 180)}
         ],
         x,
         y,
@@ -365,7 +365,7 @@ describe('canvasDriver', () => {
         instructions,
         [
           {call: 'save', args: []},
-          {call: 'rotate', args: [20*Math.PI/180]},
+          {call: 'rotate', args: [20 * Math.PI / 180]},
           {set: 'lineWidth', value: 1},
           {set: 'fillStyle', value: 'black'},
           {call: 'fillRect', args: [x, y, width, height]},
@@ -396,7 +396,7 @@ describe('canvasDriver', () => {
           {set: 'lineWidth', value: 1},
           {set: 'fillStyle', value: 'black'},
           {call: 'fillRect', args: [x, y, width, height]},
-          {call: 'restore', args: []},
+          {call: 'restore', args: []}
         ]
       );
     });
@@ -461,13 +461,13 @@ describe('canvasDriver', () => {
           {set: 'lineCap', value: 'square'},
           {set: 'lineJoin', value: 'mitter'},
           {set: 'strokeStyle', value: '#CCCCCC'},
-          {call: 'setLineDash', args: [5,15]},
+          {call: 'setLineDash', args: [5, 15]},
           {call: 'moveTo', args: [x, y]},
           {call: 'beginPath', args: []},
-          {call: 'lineTo', args: [x+10, y+10]},
-          {call: 'lineTo', args: [x+10, y+20]},
-          {call: 'lineTo', args: [x+20, y+10]},
-          {call: 'lineTo', args: [x+10, y+10]},
+          {call: 'lineTo', args: [x + 10, y + 10]},
+          {call: 'lineTo', args: [x + 10, y + 20]},
+          {call: 'lineTo', args: [x + 20, y + 10]},
+          {call: 'lineTo', args: [x + 10, y + 10]},
           {call: 'stroke', args: []},
           {call: 'setLineDash', args: []}
       ];
@@ -495,25 +495,25 @@ describe('canvasDriver', () => {
       );
       assert.deepEqual(
         context.lineTo.callArgs()[0],
-        [x+10, y+10]
+        [x + 10, y + 10]
       );
       assert.deepEqual(
         context.lineTo.callArgs()[1],
-        [x+10, y+20]
+        [x + 10, y + 20]
       );
       assert.deepEqual(
         context.lineTo.callArgs()[2],
-        [x+20, y+10]
+        [x + 20, y + 10]
       );
       assert.deepEqual(
         context.lineTo.callArgs()[3],
-        [x+10, y+10]
+        [x + 10, y + 10]
       );
       assert.deepEqual(
         context.stroke.callArgs()[0],
         []
       );
-    }); 
+    });
 
     it('takes an array of instructions for filled text without a width and applies them to a canvas context', () => {
       const context = {
@@ -633,7 +633,7 @@ describe('canvasDriver', () => {
       assert.deepEqual(
         context.restore.callArgs()[0],
         []
-      ); 
+      );
     });
 
     it('takes an array of instructions for a translate transformation and applies them to a canvas context', () => {
@@ -660,7 +660,7 @@ describe('canvasDriver', () => {
       };
 
       const instructions = [
-        {call: 'rotate', args: [20*Math.PI/180]}
+        {call: 'rotate', args: [20 * Math.PI / 180]}
       ];
 
       renderInstructionsToCanvas(instructions, context);
@@ -668,7 +668,7 @@ describe('canvasDriver', () => {
       assert.equal(context.rotate.callCount(), 1);
       assert.deepEqual(
         context.rotate.callArgs()[0],
-        [20*Math.PI/180]
+        [20 * Math.PI / 180]
       );
     });
 
@@ -689,6 +689,5 @@ describe('canvasDriver', () => {
         [2, 2]
       );
     });
- 
   });
 });

--- a/test/driver-test.js
+++ b/test/driver-test.js
@@ -1,5 +1,5 @@
 /* globals describe, it */
-import {translateVtreeToInstructions, renderInstructionsToCanvas, rect} from '../src/canvas-driver';
+import {translateVtreeToInstructions, renderInstructionsToCanvas, rect, line, text} from '../src/canvas-driver';
 import assert from 'assert';
 
 function methodSpy () {
@@ -24,7 +24,7 @@ describe('canvasDriver', () => {
   const height = 200;
 
   describe('translateVtreeToInstructions', () => {
-    it('takes a vtree and returns an array of instructions', () => {
+    it('takes a vtree and checks if the instructions array contains drawing a filled rectangle', () => {
       const vtree = rect({
         x,
         y,
@@ -38,16 +38,372 @@ describe('canvasDriver', () => {
       assert.deepEqual(
         instructions,
         [
+          {call: 'save', args: []},
           {set: 'lineWidth', value: 1},
           {set: 'fillStyle', value: 'black'},
-          {call: 'fillRect', args: [x, y, width, height]}
+          {call: 'fillRect', args: [x, y, width, height]},
+          {call: 'restore', args: []}
+        ]
+      );
+    });
+
+    it('takes a vtree and checks if the instructions array contains drawing a rectangular outline', () => {
+      const vtree = rect({
+        x,
+        y,
+        width,
+        height,
+        draw: [{stroke: 'black'}]
+      });
+
+      const instructions = translateVtreeToInstructions(vtree);
+
+      assert.deepEqual(
+        instructions,
+        [
+          {call: 'save', args: []},
+          {set: 'lineWidth', value: 1},
+          {set: 'strokeStyle', value: 'black'},
+          {call: 'strokeRect', args: [x, y, width, height]},
+          {call: 'restore', args: []}
+        ]
+      );
+    });
+
+    it('takes a vtree and checks if the instructions array handle nested children', () => {
+      const vtree = rect({
+        x,
+        y,
+        width,
+        height,
+        draw: [{fill: 'black'}],
+        children: [
+          rect({
+            x: 10,
+            y: 10,
+            width: 25,
+            height: 25,
+            draw: [{fill: 'black'}],
+            children: [
+              rect({
+                x: 10,
+                y: 10,
+                width: 50,
+                height: 50,
+                draw: [{stroke: 'purple'}]
+              })
+            ]
+          })
+        ]
+      });
+
+      const instructions = translateVtreeToInstructions(vtree);
+
+      assert.deepEqual(
+        instructions,
+        [
+          {call: 'save', args: []},
+          {set: 'lineWidth', value: 1},
+          {set: 'fillStyle', value: 'black'},
+          {call: 'fillRect', args: [x, y, width, height]},
+          {call: 'restore', args: []},
+          {call: 'save', args: []},
+          {set: 'lineWidth', value: 1},
+          {set: 'fillStyle', value: 'black'},
+          {call: 'fillRect', args: [10, 10, 25, 25]},
+          {call: 'restore', args: []},
+          {call: 'save', args: []},
+          {set: 'lineWidth', value: 1},
+          {set: 'strokeStyle', value: 'purple'},
+          {call: 'strokeRect', args: [20, 20, 50, 50]},
+          {call: 'restore', args: []}
+        ]
+      );
+    });
+
+    it('takes a vtree and checks if the instructions array handles relative origins', () => {
+      const vtree = rect({
+        x,
+        y,
+        width,
+        height,
+        draw: [{fill: 'black'}],
+        children: [
+          text({
+            x: 50,
+            y: 50,
+            value: 'Hello World',
+            font: '18pt Arial',
+            draw: [{fill: 'white'}]            
+          })
+        ]
+      });
+
+      const instructions = translateVtreeToInstructions(vtree);
+
+      assert.deepEqual(
+        instructions,
+        [
+          {call: 'save', args: []},
+          {set: 'lineWidth', value: 1},
+          {set: 'fillStyle', value: 'black'},
+          {call: 'fillRect', args: [x, y, width, height]},
+          {call: 'restore', args: []},
+          {call: 'save', args: []},
+          {set: 'textAlign', value: 'left'},
+          {set: 'font', value: '18pt Arial'},
+          {set: 'fillStyle', value: 'white'},
+          {call: 'fillText', args: ['Hello World', 50, 50]},
+          {call: 'restore', args: []}
+        ]
+      );
+    });
+
+    it('takes a vtree and checks if the instructions array contains drawing a line', () => {
+      const vtree = line({
+        x,
+        y,
+        style: {
+          lineCap: 'square',
+          strokeStyle: '#CCCCCC',
+          lineDash: [5,15]
+        },
+        points: [
+          {x: 10, y: 10},
+          {x: 10, y: 20},
+          {x: 20, y: 10},
+          {x: 10, y: 10}
+        ]
+      });
+
+      const instructions = translateVtreeToInstructions(vtree);      
+
+      assert.deepEqual(
+        instructions,
+        [
+          {call: 'save', args: []},
+          {set: 'lineWidth', value: 1},
+          {set: 'lineCap', value: 'square'},
+          {set: 'lineJoin', value: 'mitter'},
+          {set: 'strokeStyle', value: '#CCCCCC'},
+          {call: 'setLineDash', args: [5,15]},
+          {call: 'moveTo', args: [x, y]},
+          {call: 'beginPath', args: []},
+          {call: 'lineTo', args: [x+10, y+10]},
+          {call: 'lineTo', args: [x+10, y+20]},
+          {call: 'lineTo', args: [x+20, y+10]},
+          {call: 'lineTo', args: [x+10, y+10]},
+          {call: 'stroke', args: []},
+          {call: 'setLineDash', args: []},
+          {call: 'restore', args: []}
+        ]);
+    });
+
+    it('takes a vtree and checks if the instructions array contain drawing filled text without a width', () => {
+      const vtree = text({
+        x,
+        y,
+        value: 'Hello World',
+        font: '18pt Arial',
+        draw: [{fill: 'purple'}]
+      });
+
+      const instructions = translateVtreeToInstructions(vtree);
+
+      assert.deepEqual(
+        instructions,
+        [
+          {call: 'save', args: []},
+          {set: 'textAlign', value: 'left'},
+          {set: 'font', value: '18pt Arial'},
+          {set: 'fillStyle', value: 'purple'},
+          {call: 'fillText', args: ['Hello World', x, y]},
+          {call: 'restore', args: []}
+        ]
+      );
+    });
+
+    it('takes a vtree and checks if the instructions array contain drawing filled text including a width', () => {
+      const vtree = text({
+        x,
+        y,
+        width: width,
+        value: 'Hello World',
+        font: '18pt Arial',
+        draw: [{fill: 'purple'}]
+      });
+
+      const instructions = translateVtreeToInstructions(vtree);
+
+      assert.deepEqual(
+        instructions,
+        [
+          {call: 'save', args: []},
+          {set: 'textAlign', value: 'left'},
+          {set: 'font', value: '18pt Arial'},
+          {set: 'fillStyle', value: 'purple'},
+          {call: 'fillText', args: ['Hello World', x, y, width]},
+          {call: 'restore', args: []}
+        ]
+      );
+    });
+
+    it('takes a vtree and checks if the instructions array contain drawing stroked text without a width', () => {
+      const vtree = text({
+        x,
+        y,
+        value: 'Hello World',
+        font: '18pt Arial',
+        draw: [{stroke: 'purple'}]
+      });
+
+      const instructions = translateVtreeToInstructions(vtree);
+
+      assert.deepEqual(
+        instructions,
+        [
+          {call: 'save', args: []},
+          {set: 'textAlign', value: 'left'},
+          {set: 'font', value: '18pt Arial'},
+          {set: 'strokeStyle', value: 'purple'},
+          {call: 'strokeText', args: ['Hello World', x, y]},
+          {call: 'restore', args: []}
+        ]
+      );
+    });
+
+    it('takes a vtree and checks if the instructions array contain drawing stroked text including a width', () => {
+      const vtree = text({
+        x,
+        y,
+        width: width,
+        value: 'Hello World',
+        font: '18pt Arial',
+        draw: [{stroke: 'purple'}]
+      });
+
+      const instructions = translateVtreeToInstructions(vtree);
+
+      assert.deepEqual(
+        instructions,
+        [
+          {call: 'save', args: []},
+          {set: 'textAlign', value: 'left'},
+          {set: 'font', value: '18pt Arial'},
+          {set: 'strokeStyle', value: 'purple'},
+          {call: 'strokeText', args: ['Hello World', x, y, width]},
+          {call: 'restore', args: []}
+        ]
+      );
+    });
+
+    it('takes a vtree and checks if the instructions array contain save/restore calls', () => {
+      const vtree = rect({
+        x,
+        y,
+        width,
+        height,
+        draw: [{fill: 'black'}]
+      });
+
+      const instructions = translateVtreeToInstructions(vtree);
+
+      assert.deepEqual(
+        instructions,
+        [
+          {call: 'save', args: []},
+          {set: 'lineWidth', value: 1},
+          {set: 'fillStyle', value: 'black'},
+          {call: 'fillRect', args: [x, y, width, height]},
+          {call: 'restore', args: []},
+        ]
+      );
+    });
+
+    it('takes a vtree and checks if the instructions array contain translate transformation', () => {
+      const vtree = rect({
+        transformations: [
+          {translate: {x: 10, y: 10}}
+        ],
+        x,
+        y,
+        width,
+        height,
+        draw: [{fill: 'black'}]
+      });
+
+      const instructions = translateVtreeToInstructions(vtree);
+
+      assert.deepEqual(
+        instructions,
+        [
+          {call: 'save', args: []},
+          {call: 'translate', args: [10, 10]},
+          {set: 'lineWidth', value: 1},
+          {set: 'fillStyle', value: 'black'},
+          {call: 'fillRect', args: [x, y, width, height]},
+          {call: 'restore', args: []},
+        ]
+      );
+    });
+
+    it('takes a vtree and checks if the instructions array contain rotate transformation', () => {
+      const vtree = rect({
+        transformations: [
+          {rotate: (20*Math.PI/180)}
+        ],
+        x,
+        y,
+        width,
+        height,
+        draw: [{fill: 'black'}]
+      });
+
+      const instructions = translateVtreeToInstructions(vtree);
+
+      assert.deepEqual(
+        instructions,
+        [
+          {call: 'save', args: []},
+          {call: 'rotate', args: [20*Math.PI/180]},
+          {set: 'lineWidth', value: 1},
+          {set: 'fillStyle', value: 'black'},
+          {call: 'fillRect', args: [x, y, width, height]},
+          {call: 'restore', args: []},
+        ]
+      );
+    });
+
+    it('takes a vtree and checks if the instructions array contain scale transformation', () => {
+      const vtree = rect({
+        transformations: [
+          {scale: {x: 2, y: 2}}
+        ],
+        x,
+        y,
+        width,
+        height,
+        draw: [{fill: 'black'}]
+      });
+
+      const instructions = translateVtreeToInstructions(vtree);
+
+      assert.deepEqual(
+        instructions,
+        [
+          {call: 'save', args: []},
+          {call: 'scale', args: [2, 2]},
+          {set: 'lineWidth', value: 1},
+          {set: 'fillStyle', value: 'black'},
+          {call: 'fillRect', args: [x, y, width, height]},
+          {call: 'restore', args: []},
         ]
       );
     });
   });
 
   describe('renderInstructionsToCanvas', () => {
-    it('takes an array of instructions and applies them to a canvas context', () => {
+    it('takes an array of instructions for a filled rectangle and applies them to a canvas context', () => {
       const context = {
         fillRect: methodSpy()
       };
@@ -68,5 +424,271 @@ describe('canvasDriver', () => {
         [x, y, width, height]
       );
     });
+
+    it('takes an array of instructions for a rectangular outline and applies them to a canvas context', () => {
+      const context = {
+        strokeRect: methodSpy()
+      };
+
+      const instructions = [
+        {set: 'lineWidth', value: 1},
+        {set: 'strokeStyle', value: 'black'},
+        {call: 'strokeRect', args: [x, y, width, height]}
+      ];
+
+      renderInstructionsToCanvas(instructions, context);
+
+      assert.equal(context.lineWidth, 1);
+      assert.equal(context.strokeStyle, 'black');
+      assert.equal(context.strokeRect.callCount(), 1);
+      assert.deepEqual(
+        context.strokeRect.callArgs()[0],
+        [x, y, width, height]
+      );
+    });
+
+    it('takes an array of instructions for a line and applies them to a canvas context', () => {
+      const context = {
+        setLineDash: methodSpy(),
+        moveTo: methodSpy(),
+        beginPath: methodSpy(),
+        lineTo: methodSpy(),
+        stroke: methodSpy()
+      };
+
+      const instructions = [
+          {set: 'lineWidth', value: 1},
+          {set: 'lineCap', value: 'square'},
+          {set: 'lineJoin', value: 'mitter'},
+          {set: 'strokeStyle', value: '#CCCCCC'},
+          {call: 'setLineDash', args: [5,15]},
+          {call: 'moveTo', args: [x, y]},
+          {call: 'beginPath', args: []},
+          {call: 'lineTo', args: [x+10, y+10]},
+          {call: 'lineTo', args: [x+10, y+20]},
+          {call: 'lineTo', args: [x+20, y+10]},
+          {call: 'lineTo', args: [x+10, y+10]},
+          {call: 'stroke', args: []},
+          {call: 'setLineDash', args: []}
+      ];
+
+      renderInstructionsToCanvas(instructions, context);
+
+      assert.equal(context.lineWidth, 1);
+      assert.equal(context.strokeStyle, '#CCCCCC');
+      assert.equal(context.setLineDash.callCount(), 2);
+      assert.equal(context.moveTo.callCount(), 1);
+      assert.equal(context.beginPath.callCount(), 1);
+      assert.equal(context.lineTo.callCount(), 4);
+      assert.equal(context.stroke.callCount(), 1);
+      assert.deepEqual(
+        context.setLineDash.callArgs()[0],
+        [5, 15]
+      );
+      assert.deepEqual(
+        context.setLineDash.callArgs()[1],
+        []
+      );
+      assert.deepEqual(
+        context.moveTo.callArgs()[0],
+        [x, y]
+      );
+      assert.deepEqual(
+        context.lineTo.callArgs()[0],
+        [x+10, y+10]
+      );
+      assert.deepEqual(
+        context.lineTo.callArgs()[1],
+        [x+10, y+20]
+      );
+      assert.deepEqual(
+        context.lineTo.callArgs()[2],
+        [x+20, y+10]
+      );
+      assert.deepEqual(
+        context.lineTo.callArgs()[3],
+        [x+10, y+10]
+      );
+      assert.deepEqual(
+        context.stroke.callArgs()[0],
+        []
+      );
+    }); 
+
+    it('takes an array of instructions for filled text without a width and applies them to a canvas context', () => {
+      const context = {
+        fillText: methodSpy()
+      };
+
+      const instructions = [
+        {set: 'textAlign', value: 'left'},
+        {set: 'font', value: '18pt Arial'},
+        {set: 'fillStyle', value: 'purple'},
+        {call: 'fillText', args: ['Hello World', x, y]}
+      ];
+
+      renderInstructionsToCanvas(instructions, context);
+
+      assert.equal(context.textAlign, 'left');
+      assert.equal(context.font, '18pt Arial');
+      assert.equal(context.fillStyle, 'purple');
+      assert.equal(context.fillText.callCount(), 1);
+      assert.deepEqual(
+        context.fillText.callArgs()[0],
+        ['Hello World', x, y]
+      );
+    });
+
+    it('takes an array of instructions for filled text including a width and applies them to a canvas context', () => {
+      const context = {
+        fillText: methodSpy()
+      };
+
+      const instructions = [
+        {set: 'textAlign', value: 'left'},
+        {set: 'font', value: '18pt Arial'},
+        {set: 'fillStyle', value: 'purple'},
+        {call: 'fillText', args: ['Hello World', x, y, width]}
+      ];
+
+      renderInstructionsToCanvas(instructions, context);
+
+      assert.equal(context.textAlign, 'left');
+      assert.equal(context.font, '18pt Arial');
+      assert.equal(context.fillStyle, 'purple');
+      assert.equal(context.fillText.callCount(), 1);
+      assert.deepEqual(
+        context.fillText.callArgs()[0],
+        ['Hello World', x, y, width]
+      );
+    });
+
+    it('takes an array of instructions for a stroked text without a widht and applies them to a canvas context', () => {
+      const context = {
+        strokeText: methodSpy()
+      };
+
+      const instructions = [
+        {set: 'textAlign', value: 'left'},
+        {set: 'font', value: '18pt Arial'},
+        {set: 'strokeStyle', value: 'purple'},
+        {call: 'strokeText', args: ['Hello World', x, y]}
+      ];
+
+      renderInstructionsToCanvas(instructions, context);
+
+      assert.equal(context.textAlign, 'left');
+      assert.equal(context.font, '18pt Arial');
+      assert.equal(context.strokeStyle, 'purple');
+      assert.equal(context.strokeText.callCount(), 1);
+      assert.deepEqual(
+        context.strokeText.callArgs()[0],
+        ['Hello World', x, y]
+      );
+    });
+
+    it('takes an array of instructions for a stroked text including a width and applies them to a canvas context', () => {
+      const context = {
+        strokeText: methodSpy()
+      };
+
+      const instructions = [
+        {set: 'textAlign', value: 'left'},
+        {set: 'font', value: '18pt Arial'},
+        {set: 'strokeStyle', value: 'purple'},
+        {call: 'strokeText', args: ['Hello World', x, y, width]}
+      ];
+
+      renderInstructionsToCanvas(instructions, context);
+
+      assert.equal(context.textAlign, 'left');
+      assert.equal(context.font, '18pt Arial');
+      assert.equal(context.strokeStyle, 'purple');
+      assert.equal(context.strokeText.callCount(), 1);
+      assert.deepEqual(
+        context.strokeText.callArgs()[0],
+        ['Hello World', x, y, width]
+      );
+    });
+
+    it('takes an array of instructions for saving/restoring state and applies them to a canvas context', () => {
+      const context = {
+        save: methodSpy(),
+        restore: methodSpy()
+      };
+
+      const instructions = [
+        {call: 'save', args: []},
+        {call: 'restore', args: []}
+      ];
+
+      renderInstructionsToCanvas(instructions, context);
+
+      assert.equal(context.save.callCount(), 1);
+      assert.equal(context.restore.callCount(), 1);
+      assert.deepEqual(
+        context.save.callArgs()[0],
+        []
+      );
+      assert.deepEqual(
+        context.restore.callArgs()[0],
+        []
+      ); 
+    });
+
+    it('takes an array of instructions for a translate transformation and applies them to a canvas context', () => {
+      const context = {
+        translate: methodSpy()
+      };
+
+      const instructions = [
+        {call: 'translate', args: [10, 10]}
+      ];
+
+      renderInstructionsToCanvas(instructions, context);
+
+      assert.equal(context.translate.callCount(), 1);
+      assert.deepEqual(
+        context.translate.callArgs()[0],
+        [10, 10]
+      );
+    });
+
+    it('takes an array of instructions for a rotate transformation and applies them to a canvas context', () => {
+      const context = {
+        rotate: methodSpy()
+      };
+
+      const instructions = [
+        {call: 'rotate', args: [20*Math.PI/180]}
+      ];
+
+      renderInstructionsToCanvas(instructions, context);
+
+      assert.equal(context.rotate.callCount(), 1);
+      assert.deepEqual(
+        context.rotate.callArgs()[0],
+        [20*Math.PI/180]
+      );
+    });
+
+    it('takes an array of instructions for a scale transformation and applies them to a canvas context', () => {
+      const context = {
+        scale: methodSpy()
+      };
+
+      const instructions = [
+        {call: 'scale', args: [2, 2]}
+      ];
+
+      renderInstructionsToCanvas(instructions, context);
+
+      assert.equal(context.scale.callCount(), 1);
+      assert.deepEqual(
+        context.scale.callArgs()[0],
+        [2, 2]
+      );
+    });
+ 
   });
 });

--- a/test/driver-test.js
+++ b/test/driver-test.js
@@ -1,0 +1,72 @@
+/* globals describe, it */
+import {translateVtreeToInstructions, renderInstructionsToCanvas, rect} from '../src/canvas-driver';
+import assert from 'assert';
+
+function methodSpy () {
+  let called = 0;
+  let callArgs = [];
+
+  const stub = (...args) => {
+    called += 1;
+    callArgs.push(args);
+  }
+
+  stub.callCount = () => called;
+  stub.callArgs = () => callArgs;
+
+  return stub;
+}
+
+describe('canvasDriver', () => {
+  const x = 0;
+  const y = 0;
+  const width = 200;
+  const height = 200;
+
+  describe('translateVtreeToInstructions', () => {
+    it('takes a vtree and returns an array of instructions', () => {
+      const vtree = rect({
+        x,
+        y,
+        width,
+        height,
+        draw: [{fill: 'black'}]
+      });
+
+      const instructions = translateVtreeToInstructions(vtree);
+
+      assert.deepEqual(
+        instructions,
+        [
+          {set: 'lineWidth', value: 1},
+          {set: 'fillStyle', value: 'black'},
+          {call: 'fillRect', args: [x, y, width, height]}
+        ]
+      );
+    });
+  });
+
+  describe('renderInstructionsToCanvas', () => {
+    it('takes an array of instructions and applies them to a canvas context', () => {
+      const context = {
+        fillRect: methodSpy()
+      };
+
+      const instructions = [
+        {set: 'lineWidth', value: 1},
+        {set: 'fillStyle', value: 'black'},
+        {call: 'fillRect', args: [x, y, width, height]}
+      ];
+
+      renderInstructionsToCanvas(instructions, context);
+
+      assert.equal(context.lineWidth, 1);
+      assert.equal(context.fillStyle, 'black');
+      assert.equal(context.fillRect.callCount(), 1);
+      assert.deepEqual(
+        context.fillRect.callArgs()[0],
+        [x, y, width, height]
+      );
+    });
+  });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,4 @@
+test/*.js
+--timeout 3000
+--reporter progress
+--ui tdd


### PR DESCRIPTION
Instead of calling canvas directly as we walk the vtree, generate a flat array of instructions from the vtree and render them to the canvas context separately.

Pros to this approach:
- Easier to test
- Allows for a more functional style
- Means we can optimize the generated instructions (remove duplicate sets)

Cons:
- Performance? This is probably a bit slower than calling canvas context directly
- Abstraction. Adds another layer that needs to be understood when reading the code.

@schempy I consider providing you with an example of how to mock canvas but I don't really use mocking libraries in JS

I started writing the proposed refactor and I added some tests. I was wondering if you'd be interested in finishing off the implementation/tests.

Here are some TODOs if you are:
- [x] Test/implement strokeRect
- [x] Test/implement children
- [x] Test/implement lines
- [x] Test/implement font
- [x] Test/implement hooks
- [x] Test/implement relative origin
- [x] Test/implement text
