### PR TITLE
Add polygons

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ polygon({
 	],
 	draw: {
 		stroke: '#000',
-    fill: '#ccc'
+		fill: '#ccc'
 	},
 })
 ```

--- a/README.md
+++ b/README.md
@@ -158,6 +158,35 @@ line({
 })
 ```
 
+### <a id="polygon"></a> `polygon(params = {})`
+
+Draws line(s) given an object containing drawing parameters.
+
+#### params {}:
+
+- `points: array` List of point objects that specify the x/y coordinates for each point of the polygon. Using less than 3 points is a terrible way to draw a line.
+- `draw: array` List of drawing operation objects.
+	- `fill: string` The color or style to use inside the polygon. If not present, the polygon will not be filled.
+	- `stroke: string` The color or style to use as the stroke style. If not present, the polygon will not have an outline.
+- `children: array` List of child drawing shapes or text. This property is **optional**.
+
+#### Example:
+```js
+polygon({
+	points: [
+		{x: 10, y: 0},
+		{x: 0, y: 10},
+		{x: 0, y: 30},
+		{x: 30, y: 30},
+		{x: 30, y: 10} // a house shaped polygon
+	],
+	draw: {
+		stroke: '#000',
+    fill: '#ccc'
+	},
+})
+```
+
 ### <a id="text"></a> `text(options = {})`
 
 Draws text given an object containing drawing parameters.

--- a/examples/flappy-bird/app.js
+++ b/examples/flappy-bird/app.js
@@ -1,4 +1,4 @@
-import {rect, text} from '../../src/canvas-driver';
+import {rect, text, polygon} from '../../src/canvas-driver';
 
 import {Observable} from 'rx';
 
@@ -54,38 +54,31 @@ function renderBird (bird) {
     y: bird.y + bird.width / 2
   };
 
-  const birdAngle = Math.atan(bird.velocity.y);
+  const birdAngle = Math.atan(bird.velocity.y) / 2;
+  const birdPoints = (bird) => (
+    [
+      {x: 0, y: 10},
+      {x: 0, y: bird.height},
+      {x: bird.width - 10, y: bird.height},
+      {x: bird.width - 7, y: 10},
+      {x: bird.width, y: 10},
+      {x: bird.width, y: 0},
+      {x: bird.width - 7, y: 0},
+      {x: bird.width - 10, y: 10}
+    ]
+  )
 
   return (
-    rect({
+    polygon({
       transformations: [
         {translate: birdCenter},
-        {rotate: birdAngle}
+        {rotate: birdAngle},
+        {translate: {x: bird.width / -2, y: bird.height / -2}}
       ],
-      ...bird,
-
-      x: bird.width / -2,
-      y: bird.height / -2,
+      points: birdPoints(bird),
       draw: [
         {fill: 'orange'},
         {stroke: 'black', lineWidth: 2}
-      ]
-    }, [
-      renderBirdHead(bird)
-    ])
-  );
-}
-
-function renderBirdHead (bird) {
-  return (
-    rect({
-      x: bird.width * 0.9,
-      y: bird.height * (-0.3),
-      width: bird.width * 0.4,
-      height: bird.height * 0.4,
-      draw: [
-        {fill: 'orange'},
-        {stroke: 'black', lineWidth: 1}
       ]
     })
   );


### PR DESCRIPTION
Implements polygons according to #15 

Also, I propose refactoring all the `translate<element>` functions to the patters I used for `translatePolygon` (`concat` a bunch of sub-lists to create the operation list for the element). Opinions?
